### PR TITLE
Fix the path prefix when building as a GitHub page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Nami's blog",
 	"scripts": {
 		"build": "npx @11ty/eleventy",
-		"build-ghpages": "npx @11ty/eleventy --pathprefix=/eleventy-base-blog/",
+		"build-ghpages": "npx @11ty/eleventy --pathprefix=/nami-writes/",
 		"start": "npx @11ty/eleventy --serve --quiet",
 		"debug": "DEBUG=Eleventy* npx @11ty/eleventy",
 		"debugstart": "DEBUG=Eleventy* npx @11ty/eleventy --serve --quiet",
@@ -12,7 +12,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/11ty/eleventy-base-blog.git"
+		"url": "git://github.com/nsunami/nami-writes.git"
 	},
 	"author": {
 		"name": "Nami Sunami",


### PR DESCRIPTION
Fixing the prefix path from the default Eleventy one.