### PR TITLE
Remove the prefix for building the site

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Nami's blog",
 	"scripts": {
 		"build": "npx @11ty/eleventy",
-		"build-ghpages": "npx @11ty/eleventy --pathprefix=/nami-writes/",
+		"build-ghpages": "npx @11ty/eleventy",
 		"start": "npx @11ty/eleventy --serve --quiet",
 		"debug": "DEBUG=Eleventy* npx @11ty/eleventy",
 		"debugstart": "DEBUG=Eleventy* npx @11ty/eleventy --serve --quiet",


### PR DESCRIPTION
This PR resolves the issue of the links becoming blog.namisunami.com/nami-writes. I wanted it to be blog.namisunami.com/

Off to a good start! 