### PR TITLE
fix: migrate to ES6 module syntax in eleventy configuration

### DIFF
--- a/eleventy.config.drafts.js
+++ b/eleventy.config.drafts.js
@@ -24,11 +24,7 @@ function eleventyComputedExcludeFromCollections() {
 	};
 }
 
-module.exports.eleventyComputedPermalink = eleventyComputedPermalink;
-module.exports.eleventyComputedExcludeFromCollections =
-	eleventyComputedExcludeFromCollections;
-
-module.exports = (eleventyConfig) => {
+export default function (eleventyConfig) {
 	eleventyConfig.addGlobalData(
 		"eleventyComputed.permalink",
 		eleventyComputedPermalink
@@ -54,4 +50,4 @@ module.exports = (eleventyConfig) => {
 
 		logged = true;
 	});
-};
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "nami-writes",
 	"version": "1.0.0",
 	"description": "Nami's blog",
+	"type": "module",
 	"scripts": {
 		"post-today": "sh ./scripts/createNewPost.sh",
 		"build": "npx @11ty/eleventy",


### PR DESCRIPTION
This PR fixes the warning resulting from the project being in CommonJS. Migrated to ES6.

```
(node:77605) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/nami/dev/nami-writes/content/blog/blog.11tydata.js is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /Users/nami/dev/nami-writes/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
```